### PR TITLE
feat: add script in head to avoid inline option increases page size

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,6 @@ plugins:
 - search
 - toggle-sidebar:
     # async: True
-    inline: True
     # javascript: ./toggle-sidebar.js
     show_navigation_by_default: False
     show_toc_by_default: False

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@
 # Version pinning is used to prevent accidentially breaking my CI pipeline. You can probably use whatever version you like to use, as long as it is somewhat recent
 mkdocs>=1.5
 mkdocs-material
+beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ babel==2.17.0
     # via mkdocs-material
 backrefs==5.9
     # via mkdocs-material
+beautifulsoup4==4.13.4
+    # via -r requirements.in
 certifi==2025.7.14
     # via requests
 charset-normalizer==3.4.2
@@ -15,7 +17,10 @@ charset-normalizer==3.4.2
 click==8.1.8
     # via mkdocs
 colorama==0.4.6
-    # via mkdocs-material
+    # via
+    #   click
+    #   mkdocs
+    #   mkdocs-material
 ghp-import==2.1.0
     # via mkdocs
 idna==3.10
@@ -78,6 +83,10 @@ requests==2.32.4
     # via mkdocs-material
 six==1.17.0
     # via python-dateutil
+soupsieve==2.7
+    # via beautifulsoup4
+typing-extensions==4.14.1
+    # via beautifulsoup4
 urllib3==2.5.0
     # via requests
 watchdog==6.0.0


### PR DESCRIPTION
This pr make script in `<head>` to add page load speed and improve load times and reduce flickering on page (re-)load. 