### PR TITLE
Fix toggle button visibility breakpoint for toc.integrate and navigation-only modes

### DIFF
--- a/src/mkdocs_toggle_sidebar_plugin/__init__.py
+++ b/src/mkdocs_toggle_sidebar_plugin/__init__.py
@@ -182,6 +182,10 @@ class Plugin(BasePlugin[PluginConfig]):
         data = data.replace("TOC_DEFAULT_PLACEHOLDER", "true" if self.config.show_toc_by_default else "false")
         data = data.replace("NAVIGATION_DEFAULT_PLACEHOLDER", "true" if self.config.show_toc_by_default else "false")
         data = data.replace("TOGGLE_BUTTON_PLACEHOLDER", self.config.toggle_button)
+        # With Material's 'toc.integrate' feature the TOC is part of the navigation sidebar,
+        # which changes below which width the toggle button can still toggle anything visible
+        theme_features = config.theme.get("features") or []
+        data = data.replace("TOC_IS_INTEGRATED_PLACEHOLDER", "true" if "toc.integrate" in theme_features else "false")
         data = data.replace("BUTTON_TOGGLE_ICON_PLACEHOLDER", escape_for_javascript_string(self.config.button_toggle_icon))
         data = data.replace("BUTTON_TOGGLE_BOTH_TOOLTIP_PLACEHOLDER", escape_for_javascript_string(self.config.button_toggle_both_tooltip))
         data = data.replace("BUTTON_TOGGLE_NAV_TOOLTIP_PLACEHOLDER", escape_for_javascript_string(self.config.button_toggle_nav_tooltip))

--- a/src/mkdocs_toggle_sidebar_plugin/material.js
+++ b/src/mkdocs_toggle_sidebar_plugin/material.js
@@ -1,6 +1,13 @@
 const setCombinedVisibility = (showNavigation, showTOC) => {
-    // Hide the button when on mobile (and menu us shown as hamburger menu anyways).
-    // Uses the 60em threshold that is used for hiding the TOC, search bar, repo info (name + stars), etc
+    // Hide the button when everything it toggles is hidden anyways (and the menu is shown as hamburger menu).
+    // The navigation sidebar collapses into the drawer (with the theme's own hamburger button) below 76.1875em.
+    // The TOC column stays visible down to the 60em threshold (also used for hiding the search bar,
+    // repo info (name + stars), etc), unless the theme's 'toc.integrate' feature moves the TOC inside
+    // the navigation sidebar - then it collapses together with the navigation at 76.1875em.
+    const toggleButtonMode = "TOGGLE_BUTTON_PLACEHOLDER";
+    const tocIsIntegrated = TOC_IS_INTEGRATED_PLACEHOLDER;
+    const canToggleTocColumn = (toggleButtonMode == "toc" || toggleButtonMode == "all") && !tocIsIntegrated;
+    const buttonHideBreakpoint = canToggleTocColumn ? "60em" : "76.1875em";
 
     let style = `
 .mkdocs-toggle-sidebar-button {
@@ -9,7 +16,7 @@ const setCombinedVisibility = (showNavigation, showTOC) => {
     margin-left: 1rem;
 }
 
-@media screen and (max-width: 60em) {
+@media screen and (max-width: ${buttonHideBreakpoint}) {
     .mkdocs-toggle-sidebar-button {
         display: none;
     }


### PR DESCRIPTION
## Problem

Version 0.0.8 moved the width below which the header toggle button is hidden from `76.1875em` down to `60em` (the fix for #11). That is correct for standard Material layouts, where the separate TOC column stays visible down to 60em and the button still has something to toggle. But in two configurations the button now stays visible between 60em and 76.1875em while everything it toggles is already collapsed into the drawer:

- **`toc.integrate`**: the TOC lives inside the navigation sidebar, which collapses into the drawer at 76.1875em. Between 60em and 76.1875em the button toggles nothing, and the header shows two nearly identical menu buttons.
- **`toggle_button: navigation`**: same window, same problem, regardless of TOC layout — the navigation sidebar is in the drawer below 76.1875em.

Reproduction with a minimal site (`theme: material` + `features: [toc.integrate]` + `toggle_button: all`) at a 1100px viewport — drawer hamburger on the left, plugin button on the right, neither of them next to a visible sidebar:

![before: two hamburgers at 1100px](https://raw.githubusercontent.com/adamant-pwn/mkdocs-toggle-sidebar-plugin/pr14-assets/before-1100px.png)

This was hit in production by cp-algorithms.com (a `toc.integrate` site, plugin installed unpinned). The site now ships a JavaScript workaround that syncs the button's visibility with the theme's drawer hamburger — see cp-algorithms/cp-algorithms#1659; this PR would make that workaround unnecessary.

## Fix

Pick the breakpoint from what the button can still toggle: keep `60em` when the button toggles a separate TOC column (`toggle_button: toc`/`all` without `toc.integrate`), fall back to `76.1875em` otherwise. Whether `toc.integrate` is active is read from the theme's `features` list at build time and substituted as a placeholder, following the same pattern as the existing placeholders.

Same site and viewport with this PR — only the theme's drawer hamburger remains:

![after: single hamburger at 1100px](https://raw.githubusercontent.com/adamant-pwn/mkdocs-toggle-sidebar-plugin/pr14-assets/after-1100px.png)

And at 1440px the button still works as before, next to the visible sidebar:

![after: toggle button present at 1440px](https://raw.githubusercontent.com/adamant-pwn/mkdocs-toggle-sidebar-plugin/pr14-assets/after-1440px.png)

## Testing

Built a minimal site with the patched plugin in three configurations and inspected the generated `toggle-sidebar.js`:

| config | effective hide breakpoint |
|---|---|
| `toc.integrate` + `toggle_button: all` | `76.1875em` ✔ (was `60em`, double hamburger) |
| no integrate + `toggle_button: all` | `60em` ✔ (unchanged, keeps #11 fixed) |
| no integrate + `toggle_button: navigation` | `76.1875em` ✔ |

The generated file passes `node --check`. The screenshots above are from these builds (served with `python -m http.server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
