### PR TITLE
Fix show_navigation_by_default being ignored

### DIFF
--- a/src/mkdocs_toggle_sidebar_plugin/__init__.py
+++ b/src/mkdocs_toggle_sidebar_plugin/__init__.py
@@ -180,7 +180,7 @@ class Plugin(BasePlugin[PluginConfig]):
 
         data = data.replace("THEME_DEPENDENT_FUNCTION_DEFINITION_PLACEHOLDER", self.theme_function_definitions or "")
         data = data.replace("TOC_DEFAULT_PLACEHOLDER", "true" if self.config.show_toc_by_default else "false")
-        data = data.replace("NAVIGATION_DEFAULT_PLACEHOLDER", "true" if self.config.show_toc_by_default else "false")
+        data = data.replace("NAVIGATION_DEFAULT_PLACEHOLDER", "true" if self.config.show_navigation_by_default else "false")
         data = data.replace("TOGGLE_BUTTON_PLACEHOLDER", self.config.toggle_button)
         data = data.replace("BUTTON_TOGGLE_ICON_PLACEHOLDER", escape_for_javascript_string(self.config.button_toggle_icon))
         data = data.replace("BUTTON_TOGGLE_BOTH_TOOLTIP_PLACEHOLDER", escape_for_javascript_string(self.config.button_toggle_both_tooltip))


### PR DESCRIPTION
## Problem

The `NAVIGATION_DEFAULT_PLACEHOLDER` substitution in `get_toggle_sidebar_javascript` reads `show_toc_by_default` instead of `show_navigation_by_default`:

```python
data = data.replace("TOC_DEFAULT_PLACEHOLDER", "true" if self.config.show_toc_by_default else "false")
data = data.replace("NAVIGATION_DEFAULT_PLACEHOLDER", "true" if self.config.show_toc_by_default else "false")
```

As a result, `show_navigation_by_default` has no effect at all (the README documents it as "Whether to show the navigation by default"), and `show_toc_by_default: false` hides *both* sidebars by default. This appears to date back to 888761f (Sep 2023), so it affects every released version.

Reproduction on current `main`, building with `show_navigation_by_default: false` — the generated `toggle-sidebar.js` contains:

```js
const loadNavigationState = () => loadBool("NAVIGATION", true);   // should be false
```

## Fix

One word: substitute from `show_navigation_by_default`. With the fix, building with each option set to `false` independently yields:

| config | generated defaults |
|---|---|
| `show_navigation_by_default: false` | `NAVIGATION: false`, `TOC: true` ✔ |
| `show_toc_by_default: false` | `NAVIGATION: true`, `TOC: false` ✔ |

(Found while testing the configuration matrix for #14; the two PRs are independent.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)